### PR TITLE
Fix build instructions and handle different GCC versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,16 @@ If you just want to experiment with DataShield debug might be the best:
 
     cd ~/research/datashield/compiler
     mkdir build-debug
-    cd build
+    cd build-debug
     ../lto_cmake_debug.sh
-    ninja
     ninja install
 
 You can build release if you care about compile times:
 
     cd ~/research/datashield/compiler
     mkdir build-release
-    cd build
+    cd build-release
     ../lto_cmake_release.sh
-    ninja
     ninja install
 
 Baseline is the same as release for the compiler since the compiler itself is
@@ -57,9 +55,8 @@ not instrumented, but you need to build it if you want a baseline comparison for
 
     cd ~/research/datashield/compiler
     mkdir build-baseline
-    cd build
+    cd build-baseline
     ../lto_cmake_baseline.sh
-    ninja
     ninja install
 
 ## 4. Build libc
@@ -82,10 +79,10 @@ They are:
 
 ## 4. Build libcxx
 
-Building libcxx is basically the same as building libc.  It has the same three configurations.  Running `build.py all` builds everything.  Otherwise run `build.py` with no arguments for a help message.
+Building libcxx is basically the same as building libc.  It has the same three configurations.  Running `build.py <config>` builds everything.  Otherwise run `build.py` with no arguments for a help message.
 
-    cd $HOME/research/datashield/libc
-    ./build.py all
+    cd $HOME/research/datashield/libcxx
+    ./build.py <config>
 
 # Compiling Instrumented Programs
 
@@ -96,7 +93,7 @@ various protections.  There are scripts in `$HOME/research/bin` that make this m
 
 First, you should build a "Hello World" program to make sure your build is sane.
 
-     cd $HOME/research/tests/hand-written/hello_world
+     cd $HOME/research/datashield/test/hand-written/hello_world
      make
      ./test
 

--- a/libcxx/build.py
+++ b/libcxx/build.py
@@ -30,7 +30,7 @@ def build_libunwind():
     check_call("ninja install", shell=True)
 
 def print_usage():
-    print "USAGE: build.py [debug|release|baseline] <unwind|abi|cxx>"
+    print "USAGE: build.py <debug|release|baseline> [unwind|abi|cxx]"
 
 start_dir = os.getcwd()
 

--- a/libcxx/libcxx_cmake_baseline.sh
+++ b/libcxx/libcxx_cmake_baseline.sh
@@ -1,5 +1,6 @@
 DS_HOME=$HOME/research/datashield
 DS_SYSROOT=$HOME/research/datashield/ds_sysroot_baseline
+GCC_LIBDIR=$(dirname $(gcc -print-libgcc-file-name))
 cmake -GNinja -DLLVM_PATH=$DS_HOME/compiler/llvm-3.9 \
 -DCMAKE_SYSROOT=$DS_SYSROOT \
 -DCMAKE_BUILD_TYPE=Release \
@@ -14,7 +15,7 @@ cmake -GNinja -DLLVM_PATH=$DS_HOME/compiler/llvm-3.9 \
 -DLIBCXX_HAS_MUSL_LIBC=ON \
 -DLIBCXX_HAS_GCC_S_LIB=OFF \
 -DLIBCXX_ENABLE_SHARED=OFF \
--DCMAKE_STATIC_LINKER_FLAGS="/usr/lib/gcc/x86_64-linux-gnu/4.8/crtbegin.o /usr/lib/gcc/x86_64-linux-gnu/4.8/crtend.o" \
--DCMAKE_MODULE_LINKER_FLAGS="/usr/lib/gcc/x86_64-linux-gnu/4.8/crtbegin.o /usr/lib/gcc/x86_64-linux-gnu/4.8/crtend.o" \
+-DCMAKE_STATIC_LINKER_FLAGS="$GCC_LIBDIR/crtbegin.o $GCC_LIBDIR/crtend.o" \
+-DCMAKE_MODULE_LINKER_FLAGS="$GCC_LIBDIR/crtbegin.o $GCC_LIBDIR/crtend.o" \
 ../libcxx
 

--- a/libcxx/libcxx_cmake_debug.sh
+++ b/libcxx/libcxx_cmake_debug.sh
@@ -1,5 +1,6 @@
 DS_HOME=$HOME/research/datashield
 DS_SYSROOT=$HOME/research/datashield/ds_sysroot_debug
+GCC_LIBDIR=$(dirname $(gcc -print-libgcc-file-name))
 cmake -GNinja -DLLVM_PATH=$DS_HOME/compiler/llvm \
 -DCMAKE_SYSROOT=$DS_SYSROOT \
 -DCMAKE_BUILD_TYPE=Debug \
@@ -14,7 +15,7 @@ cmake -GNinja -DLLVM_PATH=$DS_HOME/compiler/llvm \
 -DLIBCXX_HAS_MUSL_LIBC=ON \
 -DLIBCXX_HAS_GCC_S_LIB=OFF \
 -DLIBCXX_ENABLE_SHARED=OFF \
--DCMAKE_STATIC_LINKER_FLAGS="/usr/lib/gcc/x86_64-linux-gnu/4.8/crtbegin.o /usr/lib/gcc/x86_64-linux-gnu/4.8/crtend.o" \
--DCMAKE_MODULE_LINKER_FLAGS="/usr/lib/gcc/x86_64-linux-gnu/4.8/crtbegin.o /usr/lib/gcc/x86_64-linux-gnu/4.8/crtend.o" \
+-DCMAKE_STATIC_LINKER_FLAGS="$GCC_LIBDIR/crtbegin.o $GCC_LIBDIR/crtend.o" \
+-DCMAKE_MODULE_LINKER_FLAGS="$GCC_LIBDIR/crtbegin.o $GCC_LIBDIR/crtend.o" \
 ../libcxx
 

--- a/libcxx/libcxx_cmake_release.sh
+++ b/libcxx/libcxx_cmake_release.sh
@@ -1,5 +1,6 @@
 DS_HOME=$HOME/research/datashield
 DS_SYSROOT=$HOME/research/datashield/ds_sysroot_release
+GCC_LIBDIR=$(dirname $(gcc -print-libgcc-file-name))
 cmake -GNinja -DLLVM_PATH=$DS_HOME/compiler/llvm \
 -DCMAKE_SYSROOT=$DS_SYSROOT \
 -DCMAKE_BUILD_TYPE=Release \
@@ -14,7 +15,7 @@ cmake -GNinja -DLLVM_PATH=$DS_HOME/compiler/llvm \
 -DLIBCXX_HAS_MUSL_LIBC=ON \
 -DLIBCXX_HAS_GCC_S_LIB=OFF \
 -DLIBCXX_ENABLE_SHARED=OFF \
--DCMAKE_STATIC_LINKER_FLAGS="/usr/lib/gcc/x86_64-linux-gnu/4.8/crtbegin.o /usr/lib/gcc/x86_64-linux-gnu/4.8/crtend.o" \
--DCMAKE_MODULE_LINKER_FLAGS="/usr/lib/gcc/x86_64-linux-gnu/4.8/crtbegin.o /usr/lib/gcc/x86_64-linux-gnu/4.8/crtend.o" \
+-DCMAKE_STATIC_LINKER_FLAGS="$GCC_LIBDIR/crtbegin.o $GCC_LIBDIR/crtend.o" \
+-DCMAKE_MODULE_LINKER_FLAGS="$GCC_LIBDIR/crtbegin.o $GCC_LIBDIR/crtend.o" \
 ../libcxx
 


### PR DESCRIPTION
It appears that some file locations may have shifted since the README file was originally created, and that it has some minor copy-and-paste errors.

Furthermore, some of the scripts have hardcoded paths for GCC 4.8, so I adjusted them to automatically detect the GCC library directory for the installed version of GCC.